### PR TITLE
Use forever to daemonize and stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "description": "Server for binder app",
   "scripts": {
-    "start": "node server",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "forever -f --uid binder server &",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "stop": "forever stop binder"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #5 

This provides an `npm stop` command.

Please note that this makes `npm start` automatically backgrounds the process. Logs are still output to stdout and stderr but it is no longer necessary to background the process manually. Calling `npm stop` will kill the background'ed process.

This also provides a mechanism by which a server started with `npm start` will restart itself if it crashes due to a programming error that isn't handled in the app.
