### PR TITLE
Provide additional fields on the profile route

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ Request:
 ```javascript
 PUT http://localhost:8080/api/profiles/123
 {
-  "bio": "My name is Chris, I'm a fourth year BCS student who...",
   "name": "Christopher Foster",
+  "bio": "My name is Chris, I'm a fourth year BCS student who...",
+  "program": "Computer Science",
+  "phone": "(250) 572-7938",
+  "year": 4,
   "courses": [
     "COMP2160",
     "COMP3550",
@@ -55,8 +58,11 @@ X-Powered-By: Express
 
 {
   "id": "123",
-  "bio": "My name is Chris, I'm a fourth year BCS student who...",
   "name": "Christopher Foster",
+  "bio": "My name is Chris, I'm a fourth year BCS student who...",
+  "program": "Computer Science", 
+  "phone": "(250) 572-7938", 
+  "year": 4,
   "courses": [
     "COMP2160",
     "COMP3550",
@@ -69,7 +75,7 @@ X-Powered-By: Express
 
 Route: `GET /api/suggestions`
 
-Note: Returns a list of suggested profiles you may like or dislike.
+Note: Returns a list of suggested profiles you may like or dislike. The suggestions route does not return phone numbers for privacy reasons. The suggestions route also does not return your own profile, or any profiles that you have already placed a Like or Dislike for.
 
 Request:
 ```javascript
@@ -88,13 +94,16 @@ X-Powered-By: Express
 
 [
   {
-    "bio": "My name is John Doe", 
+    "id": "123",
+    "name": "Christopher Foster",
+    "bio": "My name is Chris, I'm a fourth year BCS student who...",
+    "program": "Computer Science", 
+    "year": 4,
     "courses": [
-      "COMP2160", 
-      "COMP3333"
-    ], 
-    "id": "555", 
-    "name": "John Doe"
+      "COMP2160",
+      "COMP3550",
+      "COMP4550"
+    ]
   }
 ]
 ```
@@ -186,13 +195,17 @@ X-Powered-By: Express
 
 [
   {
-    "bio": "My name is John Doe", 
+    "id": "123",
+    "name": "Christopher Foster",
+    "bio": "My name is Chris, I'm a fourth year BCS student who...",
+    "program": "Computer Science", 
+    "phone": "(250) 572-7938", 
+    "year": 4,
     "courses": [
-      "COMP2160", 
-      "COMP3333"
-    ], 
-    "id": "555", 
-    "name": "John Doe"
+      "COMP2160",
+      "COMP3550",
+      "COMP4550"
+    ]
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Any request to the API requires an `Authorization` header. This header is design
 
 Route: `PUT /api/profiles/:id`
 
-Note: This route allows you to update your profile. Please note you are only able to update your own profile, so the `id` parameter should be the same as your bearer token.
+Note: This route allows you to update your profile. Please note you are only able to update your own profile, so the `id` parameter should be the same as your bearer token. The profile route requires a phone number so that you can be matched.
 
 Request:
 ```javascript

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -10,7 +10,11 @@ module.exports.put = put;
 function put(req, res, next) {
   if (req.params.id != req.user) {
     var err = { error : 'You can only update your own profile' };
-    return res.status(403).send(err);
+    return res.status(401).send(err);
+  }
+  if (!req.body.phone) {
+    var err = { error : 'You must provide a phone number' };
+    return res.status(400).send(err);
   }
   var profile = {
     id      : req.user,

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -18,6 +18,7 @@ function put(req, res, next) {
     bio     : req.body.bio || '',
     program : req.body.program || '',
     year    : req.body.year || 0,
+    phone   : req.body.phone || '',
     courses : req.body.courses || []
   };
   r.table('Profile')

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -16,6 +16,8 @@ function put(req, res, next) {
     id      : req.user,
     name    : req.body.name || '',
     bio     : req.body.bio || '',
+    program : req.body.program || '',
+    year    : req.body.year || 0,
     courses : req.body.courses || []
   };
   r.table('Profile')

--- a/server/routes/suggestions.js
+++ b/server/routes/suggestions.js
@@ -1,4 +1,3 @@
-
 /* Suggestions
  * Return user profiles to the user
  */
@@ -20,6 +19,9 @@ function get(req, res, next) {
     .eq(0);
   })
   .then(users => {
+    users.forEach(user => {
+      delete user.phone;
+    });
     res.send(users);
   })
   .catch(next);


### PR DESCRIPTION
This provides `phone`, `program`, and `year` on the profile route and updates documentation.

Note that the `PUT /profiles/:id` route now _requires_ `phone` to be present. Phone number is also not included in the `GET /suggestions` route, since you need to be matched with the person to see it. Phone numbers will appear in `GET /matches`.

Resolves #3 
Resolves #7 
Resolves #8 
