### PR TITLE
Add support for photo parameter (size limit 3MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Any request to the API requires an `Authorization` header. This header is design
 
 Route: `PUT /api/profiles/:id`
 
-Note: This route allows you to update your profile. Please note you are only able to update your own profile, so the `id` parameter should be the same as your bearer token. The profile route requires a phone number so that you can be matched.
+Note: This route allows you to update your profile. Please note you are only able to update your own profile, so the `id` parameter should be the same as your bearer token. The profile route requires a phone number so that you can be matched. The photo parameter is limited to 3MB in size.
 
 Request:
 ```javascript
@@ -43,6 +43,7 @@ PUT http://localhost:8080/api/profiles/123
 {
   "name": "Christopher Foster",
   "bio": "My name is Chris, I'm a fourth year BCS student who...",
+  "photo": "data:image/png;base64,iVBORw0K...Ggg==",
   "program": "Computer Science",
   "phone": "(250) 572-7938",
   "year": 4,
@@ -68,6 +69,7 @@ X-Powered-By: Express
   "id": "123",
   "name": "Christopher Foster",
   "bio": "My name is Chris, I'm a fourth year BCS student who...",
+  "photo": "data:image/png;base64,iVBORw0K...Ggg==",
   "program": "Computer Science", 
   "phone": "(250) 572-7938", 
   "year": 4,
@@ -105,6 +107,7 @@ X-Powered-By: Express
     "id": "123",
     "name": "Christopher Foster",
     "bio": "My name is Chris, I'm a fourth year BCS student who...",
+    "photo": "data:image/png;base64,iVBORw0K...Ggg==",
     "program": "Computer Science", 
     "year": 4,
     "courses": [
@@ -206,6 +209,7 @@ X-Powered-By: Express
     "id": "123",
     "name": "Christopher Foster",
     "bio": "My name is Chris, I'm a fourth year BCS student who...",
+    "photo": "data:image/png;base64,iVBORw0K...Ggg==",
     "program": "Computer Science", 
     "phone": "(250) 572-7938", 
     "year": 4,

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -7,7 +7,7 @@ var r = require('../r');
 
 module.exports.put = put;
 
-const photoLimit = 2*1024*1024;
+const photoLimit = 3*1024*1024;
 
 function put(req, res, next) {
   if (req.params.id != req.user) {

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -7,6 +7,8 @@ var r = require('../r');
 
 module.exports.put = put;
 
+const photoLimit = 2*1024*1024;
+
 function put(req, res, next) {
   if (req.params.id != req.user) {
     var err = { error : 'You can only update your own profile' };
@@ -16,6 +18,10 @@ function put(req, res, next) {
     var err = { error : 'You must provide a phone number' };
     return res.status(400).send(err);
   }
+  if (Buffer.byteLength(req.body.photo, 'utf8') > photoLimit) {
+    var err = { error : 'Maximum size for `photo` exceeded' };
+    return res.status(400).send(err);
+  }
   var profile = {
     id      : req.user,
     name    : req.body.name || '',
@@ -23,6 +29,7 @@ function put(req, res, next) {
     program : req.body.program || '',
     year    : req.body.year || 0,
     phone   : req.body.phone || '',
+    photo   : req.body.photo || '',
     courses : req.body.courses || []
   };
   r.table('Profile')


### PR DESCRIPTION
@mitchhentges this isn't 16MB, but testing on various phones indicated that even on the most recent Nexus 6 camera is image size isn't higher than 2.5MB. 

Let me know if this needs to be higher though, but note the blood curling screams of the database being abused.
